### PR TITLE
Fix/wlt qa 01 blocks home

### DIFF
--- a/app/design/frontend/Weltpixel/clone/web/css/source/home/_awesome-extencsions.less
+++ b/app/design/frontend/Weltpixel/clone/web/css/source/home/_awesome-extencsions.less
@@ -153,6 +153,7 @@
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
     body#html-body.cms-home {
         .awesome-extensions {
+            padding-top: 100px;
             &__wrapper {
                 .pagebuilder-column-line {
                     padding: 0 40px;
@@ -247,6 +248,8 @@
             max-width: 100%;
         }
         .awesome-extensions {
+            padding-top: 0;
+            margin: 150px 0;
             &__sections {
                 padding: 0 150px;
             }
@@ -258,7 +261,7 @@
             }
             .quote-4 {
                 .pagebuilder-column-line {
-                    padding: 150px 15px;
+                    padding: 150px 0 100px 0;
                 }
             }
             &__section-magento2 {
@@ -268,6 +271,10 @@
                     }
                     &__sections-image {
                         text-align: left;
+                    }
+                    &--span {
+                        margin-top: 0;
+                        padding-top: 150px;
                     }
                 }
             }

--- a/app/design/frontend/Weltpixel/clone/web/css/source/home/_customer-development.less
+++ b/app/design/frontend/Weltpixel/clone/web/css/source/home/_customer-development.less
@@ -41,6 +41,9 @@
                             font-weight: 700;
                         }
                     }
+                    &:active {
+                        opacity: 0.8;
+                    }
                 }
                 [aria-expanded="false"] {
                     .title-buttons--close-expand {
@@ -80,15 +83,6 @@
             }
         }
     }
-}
-
-
-
-//
-//  Mobile
-//  _____________________________________________
-.media-width(@extremum, @break) when (@extremum = 'max') and (@break = @screen__m) {
-
 }
 
 //
@@ -143,7 +137,7 @@
 //  _____________________________________________
 @media  (min-width: 1200px) {
 
-    body.cms-ome {
+    body.cms-home {
         .customer-development {
             &__content {
                 [data-role="title"] {
@@ -156,4 +150,5 @@
             }
         }
     }
+
 }

--- a/app/design/frontend/Weltpixel/clone/web/css/source/home/_google-Analytics-4.less
+++ b/app/design/frontend/Weltpixel/clone/web/css/source/home/_google-Analytics-4.less
@@ -24,7 +24,7 @@
                 .config-font ( @fuente1, 40px, 800, normal, 59px, 0px, @color-oscuro );
             }
             &__text {
-                margin-bottom: 10px;
+                /*margin-bottom: 10px;*/
                 p {
                     .config-font ( @fuente2, 14px, 400, normal, 1.5, 0.5px, #575757 );
                 }

--- a/app/design/frontend/Weltpixel/clone/web/css/source/home/_industry-partners.less
+++ b/app/design/frontend/Weltpixel/clone/web/css/source/home/_industry-partners.less
@@ -11,6 +11,7 @@
     body.cms-home {
 
         .industry-partners {
+            padding-bottom: 50px;
             &__content {
                 margin: 50px 0 0;
                 padding: 0 15px;

--- a/app/design/frontend/Weltpixel/clone/web/css/source/home/_post-list.less
+++ b/app/design/frontend/Weltpixel/clone/web/css/source/home/_post-list.less
@@ -23,6 +23,15 @@
                 margin-bottom: 20px;
                 padding: 10px 15px;
             }
+            .server-side {
+                order: 2;
+            }
+            .google-analytics-4 {
+                order: 3;
+            }
+            .product-update {
+                order: 1;
+            }
             &--image {
                 min-height: 250px;
                 a {
@@ -45,7 +54,7 @@
                         color: inherit;
                         text-decoration: none;
                     }
-                }  
+                }
             }
             &--text {
                 margin-bottom: 40px;
@@ -81,6 +90,11 @@
             &__items {
                 width: 100%;
             }
+            &--image {
+                a {
+                    margin: 15px 0;
+                }
+            }
         }
     }
 
@@ -94,5 +108,5 @@
 //  _____________________________________________
 
 .media-width(@extremum, @break) when (@extremum = 'min') and (@break = @screen__m) {
-  
+
 }


### PR DESCRIPTION
**ISSUES RESUELTOS:**

**1. **wlt003-3-block-home****
* ajustes espacio entre letras del texto
* revisar el margen entre el boton y el texto en todas las vistas

**2. wlt003-11-block-home**
* En vista mobile es necesario agregar un padding-bottom de 50px al block

**3. wlt003-13-block-home**
* En el momento de expandir activar la funcionalidad de expandir hay un pequeño parpadeo azul (opcional)
* En vistas superiores a 1200px darle una ubicacion mas precisa a los botones de expancion

**4. wlt003-21-block-home**
* Revisar padding top en vistas superiores a 768px a 1200px del block
* revisar margin-top y margin-bottom en vistas superiores a 1200px del block
* revisar el margen en vistas superiores a 1200px en la siguiente clase awesome-extensions--span

**5. wlt003-23-block-home**
* Verificar el orden de las tarjetas en vista mobile (opcional lo mas factible es que la pagina haya sufrido modificaciones)
* verificar espaciado o margen en las vistas suepriores a 768px
* verificar el align-text en vistas superiores a 768px
