### PR TITLE
make improvements to slider styles

### DIFF
--- a/app/code/AgSoftware/SlickSlider/view/frontend/web/css/source/slick-theme.less
+++ b/app/code/AgSoftware/SlickSlider/view/frontend/web/css/source/slick-theme.less
@@ -110,7 +110,7 @@
     display: flex;
     position: absolute;
     right: 50%;
-    bottom: -50%;
+    bottom: -136px;
     transform: translate(50%, -50%);
 
     li {
@@ -188,7 +188,7 @@
 //  Mobile
 //  _____________________________________________
 
-@media (min-width: 375px) and (max-width: 1024px){
+@media (min-width: 320px) and (max-width: 768px){
     .slider-seption {
         padding: 50px 0 100px;
         .regular {
@@ -199,13 +199,13 @@
                 right:-10px;
             }
             .slick-dots {
-                bottom: -62%;
+                bottom: -99px;
             }
         }
     }
 }
 
-@media (min-width: 1024px) {
+@media (min-width: 1200px) {
     .slider-seption {
         padding: 150px 0;
     }


### PR DESCRIPTION
issues

Revisar paddin top de la clase section-wrapper-slider bg-white, solo es corregir la media query los 150px de padding son apartir de la vista 1200px.

Revisar los botones en la vista maxima tambien los bototnes rompen el contenedor del bloque.

Bloque esta generando scroll, aplicar overflow hidden al bloque o ajustar tamaño para que no genere scroll.

Resueltos...